### PR TITLE
GH-0 | Fix screenshot job checkout to the wrong ref

### DIFF
--- a/.github/workflows/pr_jobs_screenshot_tests.yml
+++ b/.github/workflows/pr_jobs_screenshot_tests.yml
@@ -19,6 +19,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}  # Checkout the PR branch (not merge commit)
           repository: ${{ github.event.pull_request.head.repo.full_name }}  # Checkout from fork if needed
           token: ${{ secrets.GITHUB_TOKEN }}  # Need a token with push permissions
+          lfs: true  # Pull Git LFS files (screenshots are stored in LFS)
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/pr_jobs_screenshot_tests.yml
+++ b/.github/workflows/pr_jobs_screenshot_tests.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full git history for comparing changes
-          ref: ${{ github.head_ref }}  # This checks out the PR source branch
           token: ${{ secrets.GITHUB_TOKEN }}  # Need a token with push permissions
 
       - name: Set up JDK

--- a/.github/workflows/pr_jobs_screenshot_tests.yml
+++ b/.github/workflows/pr_jobs_screenshot_tests.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full git history for comparing changes
+          ref: ${{ github.event.pull_request.head.ref }}  # Checkout the PR branch (not merge commit)
+          repository: ${{ github.event.pull_request.head.repo.full_name }}  # Checkout from fork if needed
           token: ${{ secrets.GITHUB_TOKEN }}  # Need a token with push permissions
 
       - name: Set up JDK
@@ -94,13 +96,36 @@ jobs:
             ./gradlew executeScreenshotTests -Precord
 
       - name: Commit new screenshots
-        if: steps.run_tests.outcome == 'failure' && github.event_name == 'pull_request'
+        if: steps.run_tests.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config --local user.email "ci@github.actions.com"
           git config --local user.name "GitHub Actions"
           git add app/screenshots/debug/
           git commit -m "Update screenshots from CI" || echo "No changes to commit"
           git push
+
+      - name: Comment on fork PR about screenshots
+        if: steps.run_tests.outcome == 'failure' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '📸 Screenshot tests detected differences!\n\n' +
+                    '## Option 1: Update screenshots automatically in your fork (Recommended)\n' +
+                    '1. Go to the **Actions** tab in your fork\n' +
+                    '2. Select **"Update Screenshots (For Forks)"** workflow\n' +
+                    '3. Click **"Run workflow"** and select your branch (`' + context.payload.pull_request.head.ref + '`)\n' +
+                    '4. Wait for the workflow to complete - screenshots will be committed automatically\n' +
+                    '5. Your PR will be updated with the new screenshots\n\n' +
+                    '## Option 2: Manual download\n' +
+                    '1. Download the `screenshot-test-results` artifact from this workflow run\n' +
+                    '2. Extract `app/screenshots/debug/` to your local repository\n' +
+                    '3. Commit and push the updated screenshots\n\n' +
+                    '**Note:** Screenshots must be generated on CI to ensure consistency across different platforms.'
+            })
 
       - name: Upload Screenshot Test Results
         if: steps.run_tests.outcome == 'failure'
@@ -111,4 +136,4 @@ jobs:
             app/screenshots/debug/
             app/build/tmp/shot/screenshot/
             app/build/reports/shot/debug/verification/
-          retention-days: 1
+          retention-days: 7

--- a/.github/workflows/update_screenshots.yml
+++ b/.github/workflows/update_screenshots.yml
@@ -30,6 +30,7 @@ jobs:
           ref: ${{ github.event.inputs.branch || github.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          lfs: true  # Pull Git LFS files (screenshots are stored in LFS)
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/update_screenshots.yml
+++ b/.github/workflows/update_screenshots.yml
@@ -1,0 +1,112 @@
+name: Update Screenshots (For Forks)
+
+# This workflow is designed for external contributors working in forks.
+# It allows you to manually trigger screenshot generation on CI, which will
+# automatically commit updated screenshots to your branch.
+#
+# Usage:
+# 1. Go to Actions tab in your fork
+# 2. Select "Update Screenshots (For Forks)" workflow
+# 3. Click "Run workflow"
+# 4. Select your branch and run
+# 5. Screenshots will be automatically committed to your branch
+# 6. Open/update your PR with the committed screenshots
+
+on:
+  workflow_dispatch:  # Manual trigger
+    inputs:
+      branch:
+        description: 'Branch to update screenshots on'
+        required: false
+        default: ''
+
+jobs:
+  update-screenshots:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-32
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 32
+          arch: x86_64
+          profile: pixel_6
+          target: google_apis
+          avd-name: ubuntu-avd-x86_64-32
+          emulator-boot-timeout: 120
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Clear old screenshots
+        run: rm -rf app/screenshots/debug/
+
+      - name: Generate new screenshots
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 32
+          arch: x86_64
+          profile: pixel_6
+          target: google_apis
+          avd-name: ubuntu-avd-x86_64-32
+          emulator-boot-timeout: 120
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew executeScreenshotTests -Precord
+
+      - name: Commit and push screenshots
+        run: |
+          git config --local user.email "ci@github.actions.com"
+          git config --local user.name "GitHub Actions"
+          git add app/screenshots/debug/
+          if git diff --staged --quiet; then
+            echo "No screenshot changes detected"
+          else
+            git commit -m "Update screenshots from CI [skip ci]"
+            git push
+            echo "✅ Screenshots updated successfully!"
+          fi
+
+      - name: Upload screenshots as artifact (backup)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-screenshots
+          path: app/screenshots/debug/
+          retention-days: 7

--- a/SCREENSHOT_CONTRIBUTION_GUIDE.md
+++ b/SCREENSHOT_CONTRIBUTION_GUIDE.md
@@ -4,6 +4,29 @@
 - Pixel 6
 - API 32
 
+## For External Contributors (Fork PRs)
+
+**Important:** Screenshots must always be generated on CI to ensure consistency across different platforms. Never generate screenshots locally!
+
+When your PR fails screenshot tests, you have two options:
+
+### Option 1: Automatic Update (Recommended)
+1. Go to the **Actions** tab in your fork repository
+2. Select **"Update Screenshots (For Forks)"** workflow
+3. Click **"Run workflow"** button
+4. Select your branch from the dropdown
+5. Click the green **"Run workflow"** button
+6. Wait for the workflow to complete (~5-10 minutes)
+7. Screenshots will be automatically committed to your branch
+8. Your PR will be updated automatically
+
+### Option 2: Manual Download
+1. Download the `screenshot-test-results` artifact from the failed workflow run
+2. Extract the `app/screenshots/debug/` folder to your local repository
+3. Commit and push the screenshots to your branch
+
+---
+
 We can consider the following items to create a rule set that guides those who will write a screenshot test of a new component. This set will be a step-by-step guide and guideline, so that even beginners can write component screenshot tests correctly and consistently.
 Android Screenshot Test Rule Set:
 ### 1. Follow Test Name Standards

--- a/app/screenshots/debug/statelayout.warninginfo.NoButtonTests_NoButton - NoTitle - MediumIcon - Warning Info Tests.png
+++ b/app/screenshots/debug/statelayout.warninginfo.NoButtonTests_NoButton - NoTitle - MediumIcon - Warning Info Tests.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03d9b1debc438cbd0f49dca1e259d9433f5ef721bd2cf234d3de3948db6a6864
+oid sha256:cf099fef46865c614ee143ab7cefb67d31d3261d92c474f6b18314958b30885e
 size 37451


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
There was a problem in #14 PR which screenshot job wasn't working for the forked repo's branch. This PR should fix the problem.
