### PR TITLE
Add KeyboardActions parameter to KPInputPasswordField and KPInputOTPF…

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1426,7 +1426,7 @@ public final class com/trendyol/design/core/inputfield/otp/ComposableSingletons$
 }
 
 public final class com/trendyol/design/core/inputfield/otp/InputOTPFieldKt {
-	public static final fun KPInputOTPField (Lcom/trendyol/design/core/inputfield/otp/InputOTPFieldStyle;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;IZLjava/lang/String;Ljava/lang/String;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V
+	public static final fun KPInputOTPField (Lcom/trendyol/design/core/inputfield/otp/InputOTPFieldStyle;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;IZLjava/lang/String;Ljava/lang/String;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;II)V
 }
 
 public abstract interface class com/trendyol/design/core/inputfield/otp/InputOTPFieldStyle {
@@ -1472,7 +1472,7 @@ public final class com/trendyol/design/core/inputfield/password/ComposableSingle
 }
 
 public final class com/trendyol/design/core/inputfield/password/InputPasswordFieldKt {
-	public static final fun KPInputPasswordField (Lcom/trendyol/design/core/inputfield/OutlinedTextFieldStyle;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZCLandroidx/compose/runtime/Composer;II)V
+	public static final fun KPInputPasswordField (Lcom/trendyol/design/core/inputfield/OutlinedTextFieldStyle;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZCLandroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/trendyol/design/core/inputfield/phone/InputPhoneNumberFieldKt {

--- a/core/src/main/java/com/trendyol/design/core/inputfield/otp/InputOTPField.kt
+++ b/core/src/main/java/com/trendyol/design/core/inputfield/otp/InputOTPField.kt
@@ -100,7 +100,10 @@ public fun KPInputOTPField(
             },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword, imeAction = ImeAction.Done),
             keyboardActions = keyboardActions ?: KeyboardActions(
-                onDone = { focusManager.clearFocus(force = true) },
+                onDone = {
+                    focusManager.clearFocus(force = true)
+                    onValueChange(otpTextValue.text)
+                },
             ),
             interactionSource = interactionSource,
             enabled = enabled,

--- a/core/src/main/java/com/trendyol/design/core/inputfield/otp/InputOTPField.kt
+++ b/core/src/main/java/com/trendyol/design/core/inputfield/otp/InputOTPField.kt
@@ -2,7 +2,6 @@
 
 package com.trendyol.design.core.inputfield.otp
 
-import android.view.KeyEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -18,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
@@ -27,9 +27,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
@@ -64,6 +64,8 @@ import com.trendyol.theme.KPDesign
  *                  This message is shown only when the field is enabled and the errorText is not null.
  * @param interactionSource The interaction source for tracking focus and other interaction states.
  *                          This parameter is optional and defaults to a newly remembered instance of MutableInteractionSource.
+ * @param keyboardActions Defines the actions to be triggered by pressing the keyboard IME.
+ *                        This parameter is optional and default is to clear focus from input field.
  */
 @ExperimentalKompostoApi
 @Composable
@@ -77,6 +79,7 @@ public fun KPInputOTPField(
     hint: String? = null,
     errorText: String? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    keyboardActions: KeyboardActions? = null,
 ) {
     var otpTextValue by remember {
         mutableStateOf(TextFieldValue(text = otp, selection = TextRange(otp.length)))
@@ -87,18 +90,7 @@ public fun KPInputOTPField(
 
     Column(modifier = modifier.fillMaxWidth()) {
         BasicTextField(
-            modifier = Modifier
-                .fillMaxWidth()
-                .onKeyEvent { keyEvent ->
-                    if (keyEvent.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_ENTER) {
-                        focusManager.clearFocus(force = true)
-                        onValueChange(otpTextValue.text)
-
-                        return@onKeyEvent true
-                    }
-
-                    false
-                },
+            modifier = Modifier.fillMaxWidth(),
             value = otpTextValue,
             onValueChange = { value ->
                 otpTextValue = value.copy(
@@ -106,7 +98,10 @@ public fun KPInputOTPField(
                     selection = TextRange(value.text.length)
                 )
             },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword, imeAction = ImeAction.Done),
+            keyboardActions = keyboardActions ?: KeyboardActions(
+                onDone = { focusManager.clearFocus(force = true) },
+            ),
             interactionSource = interactionSource,
             enabled = enabled,
             decorationBox = {

--- a/core/src/main/java/com/trendyol/design/core/inputfield/password/InputPasswordField.kt
+++ b/core/src/main/java/com/trendyol/design/core/inputfield/password/InputPasswordField.kt
@@ -26,9 +26,9 @@ import com.trendyol.design.core.R
 import com.trendyol.design.core.annotation.ExperimentalKompostoApi
 import com.trendyol.design.core.icon.KPIcon
 import com.trendyol.design.core.icon.KPIconSize
-import com.trendyol.design.core.inputfield.OutlinedTextFieldStyle
 import com.trendyol.design.core.inputfield.KPOutlinedTextField
 import com.trendyol.design.core.inputfield.KPOutlinedTextFieldStyle
+import com.trendyol.design.core.inputfield.OutlinedTextFieldStyle
 import com.trendyol.design.core.preview.PreviewTheme
 import com.trendyol.design.core.text.KPText
 import com.trendyol.theme.KPDesign
@@ -57,6 +57,8 @@ import com.trendyol.theme.KPDesign
  *                This parameter defaults to true.
  * @param mask The character used to mask the password. This defaults to PASSWORD_MASK_CHAR.
  *             The mask is applied only when the password is hidden.
+ * @param keyboardActions Defines the actions to be triggered by pressing the keyboard IME.
+ *                        This parameter is optional and default is to clear focus from input field.
  */
 @ExperimentalKompostoApi
 @Composable
@@ -69,7 +71,8 @@ public fun KPInputPasswordField(
     label: String? = null,
     errorText: String? = null,
     enabled: Boolean = true,
-    mask: Char = PASSWORD_MASK_CHAR
+    mask: Char = PASSWORD_MASK_CHAR,
+    keyboardActions: KeyboardActions? = null,
 ) {
     var text by remember { mutableStateOf(password) }
     var checked by remember { mutableStateOf(false) }
@@ -97,7 +100,9 @@ public fun KPInputPasswordField(
                 PasswordVisualTransformation(mask = mask)
             },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus(force = true) }),
+            keyboardActions = keyboardActions ?: KeyboardActions(
+                onDone = { focusManager.clearFocus(force = true) }
+            ),
             trailingIcon = {
                 IconToggleButton(
                     checked = checked,


### PR DESCRIPTION

## 📝 Pull Request Description

### What does this PR do?
In `KPInputPasswordField` and `KPInputOTPField`, removed hard-coded keyboard action and take `KeyboardActions` as a parameter in these two functions, with a default value.

## 📋 Related Issue
Related to issue #18 

## 🧪 Testing

### How has this been tested?
<!--- Describe the tests you ran to verify your changes -->
- [ ] Screenshot tests
- [ ] UI tests
- [X] Manual testing
Run the application in a phone to check if desired behavior is achieved.

### Test Coverage
- [X] Main functionality
- [ ] Edge cases
- [ ] Different Android versions
- [ ] Different screen sizes/densities
- [ ] RTL layout support
- [ ] Accessibility features

### Screenshots/Videos

## 🔍 Code Review Checklist

### General
- [X] Code follows project coding standards
- [X] Self-review completed
- [X] No debugging code left behind
- [X] Documentation updated if needed

### Testing
- [X] Existing tests still pass
- [ ] New tests added if applicable
- [ ] Screenshot tests updated if UI changed
- [ ] Edge cases covered

## 🚀 Impact Assessment

### Breaking Changes
- [ ] This change introduces breaking changes
- [X] This change is backward compatible

## 🔄 Migration Required
<!--- Is any migration needed for consumers? -->
- [X] No migration required
- [ ] Migration required (explain below)

**Migration Details:**
<!--- If migration is needed, provide details -->

## 📸 Screenshot Test Changes
<!--- If screenshot tests were updated -->
- [X] Screenshot tests were not affected
- [ ] Screenshot tests were updated
- [ ] New screenshot tests were added

**Screenshot Changes Explained:**
<!--- Explain why screenshots changed -->

---
